### PR TITLE
Travis, Podspec, Ifs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 osx_image: xcode8
 language: objective-c
 script:
-- sudo gem install cocoapods -v 1.1.0.rc.2
+- sudo gem install cocoapods -v 1.2.0.beta.1
 - pod repo update > /dev/null
 - pod lib lint --use-libraries

--- a/mParticle-Radar.podspec
+++ b/mParticle-Radar.podspec
@@ -12,8 +12,9 @@ Pod::Spec.new do |s|
   s.social_media_url        = 'https://twitter.com/mparticles'
   s.ios.deployment_target   = '8.0'
   s.ios.source_files        = 'mParticle-Radar/*.{h,m,mm}'
+  s.ios.frameworks          = 'CoreLocation'
   s.ios.dependency          'mParticle-Apple-SDK/mParticle', '~> 6.11.0'
-  s.ios.dependency          'RadarSDK', '~> 1.1'
+  s.ios.dependency          'RadarSDK', '~> 1.1.5'
   s.ios.pod_target_xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/RadarSDK/**',
                                 'OTHER_LDFLAGS' => '$(inherited) -framework "RadarSDK"' }
 end

--- a/mParticle-Radar/MPKitRadar.m
+++ b/mParticle-Radar/MPKitRadar.m
@@ -22,8 +22,6 @@
 NSString *const KEY_PUBLISHABLE_KEY = @"publishableKey";
 NSString *const KEY_RUN_AUTOMATICALLY = @"runAutomatically";
 
-NSUInteger MPKitInstanceCompanyName = 117;
-
 @interface MPKitRadar() {
     BOOL runAutomatically;
 }
@@ -45,16 +43,18 @@ NSUInteger MPKitInstanceCompanyName = 117;
     CLAuthorizationStatus status = [Radar authorizationStatus];
     BOOL hasAuthorized = status == kCLAuthorizationStatusAuthorizedAlways;
 
-    if (hasAuthorized)
+    if (hasAuthorized) {
         [Radar startTracking];
+    }
 }
 
 - (void)tryTrackOnce {
     CLAuthorizationStatus status = [Radar authorizationStatus];
     BOOL hasAuthorized = status == kCLAuthorizationStatusAuthorizedAlways || status == kCLAuthorizationStatusAuthorizedWhenInUse;
 
-    if (hasAuthorized)
+    if (hasAuthorized) {
         [Radar trackOnceWithCompletionHandler:nil];
+    }
 }
 
 #pragma mark - MPKitInstanceProtocol methods
@@ -62,19 +62,21 @@ NSUInteger MPKitInstanceCompanyName = 117;
 #pragma mark Kit instance and lifecycle
 - (nonnull instancetype)initWithConfiguration:(nonnull NSDictionary *)configuration startImmediately:(BOOL)startImmediately {
     self = [super init];
-    
+
     NSString *publishableKey = configuration[KEY_PUBLISHABLE_KEY];
     runAutomatically = [(NSNumber *)configuration[KEY_RUN_AUTOMATICALLY] boolValue];
 
-    if (!self || !publishableKey)
+    if (!self || !publishableKey) {
         return nil;
+    }
 
     [Radar initializeWithPublishableKey:publishableKey];
 
     _configuration = configuration;
 
-    if (startImmediately)
+    if (startImmediately) {
         [self start];
+    }
 
     return self;
 }
@@ -85,8 +87,9 @@ NSUInteger MPKitInstanceCompanyName = 117;
     dispatch_once(&kitPredicate, ^{
         _started = YES;
 
-        if (runAutomatically)
+        if (runAutomatically) {
             [self tryStartTracking];
+        }
 
         dispatch_async(dispatch_get_main_queue(), ^{
             NSDictionary *userInfo = @{mParticleKitInstanceKey:[[self class] kitCode]};
@@ -102,8 +105,9 @@ NSUInteger MPKitInstanceCompanyName = 117;
 #pragma mark Application
 
 - (MPKitExecStatus *)didBecomeActive {
-    if (runAutomatically)
+    if (runAutomatically) {
         [self tryTrackOnce];
+    }
 
     return [[MPKitExecStatus alloc] initWithSDKCode:[MPKitRadar kitCode] returnCode:MPKitReturnCodeSuccess];
 }
@@ -111,8 +115,9 @@ NSUInteger MPKitInstanceCompanyName = 117;
 #pragma mark Events
 
 - (MPKitExecStatus *)logout {
-    if (runAutomatically)
+    if (runAutomatically) {
         [Radar stopTracking];
+    }
 
     return [[MPKitExecStatus alloc] initWithSDKCode:[MPKitRadar kitCode] returnCode:MPKitReturnCodeSuccess];
 }
@@ -123,8 +128,9 @@ NSUInteger MPKitInstanceCompanyName = 117;
     if (identityType == MPUserIdentityCustomerId) {
         [Radar setUserId:identityString];
 
-        if (runAutomatically)
+        if (runAutomatically) {
             [self tryStartTracking];
+        }
     }
 
     return [[MPKitExecStatus alloc] initWithSDKCode:[MPKitRadar kitCode] returnCode:MPKitReturnCodeSuccess];
@@ -133,8 +139,9 @@ NSUInteger MPKitInstanceCompanyName = 117;
 #pragma mark Assorted
 
 - (MPKitExecStatus *)setOptOut:(BOOL)optOut {
-    if (runAutomatically)
+    if (runAutomatically) {
         [Radar stopTracking];
+    }
 
     return [[MPKitExecStatus alloc] initWithSDKCode:[MPKitRadar kitCode] returnCode:MPKitReturnCodeSuccess];
 }


### PR DESCRIPTION
Mainly this commit wraps the if statements with curly braces `{}`. It also updates the podspec to include `CoreLocation` as a dependency framework (even though it is specified in the Radar SDK, but CocoaPods has misbehaved in the past regarding that), and the Travis script to pull the latest CocoaPods