### PR TITLE
Upgrade Radar from 1.1.x to 1.2.x

### DIFF
--- a/mParticle-Radar.podspec
+++ b/mParticle-Radar.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.ios.source_files        = 'mParticle-Radar/*.{h,m,mm}'
   s.ios.frameworks          = 'CoreLocation'
   s.ios.dependency          'mParticle-Apple-SDK/mParticle', '~> 6.14.0'
-  s.ios.dependency          'RadarSDK', '~> 1.1.7'
+  s.ios.dependency          'RadarSDK', '~> 1.2.0'
   s.ios.pod_target_xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/RadarSDK/**',
                                 'OTHER_LDFLAGS' => '$(inherited) -framework "RadarSDK"' }
 end


### PR DESCRIPTION
1.2.x adds iOS 11 support and requires no code changes to upgrade. See https://blog.onradar.com/radar-sdk-v1-2-with-ios-11-and-android-o-support-now-available-ee5c12b9f25.