### PR TITLE
Proactively grab customer ID during initialization, bump Radar to 1.3.0 to allow anonymous tracking

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "radarlabs/radar-sdk-ios" ~> 1.2.0
+github "radarlabs/radar-sdk-ios" ~> 1.3.0
 github "mparticle/mparticle-apple-sdk" ~> 6.15.0

--- a/mParticle-Radar.podspec
+++ b/mParticle-Radar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                    = 'mParticle-Radar'
-  s.version                 = '6.15.17'
+  s.version                 = '6.15.18'
   s.summary                 = 'Radar integration for mParticle'
   s.description             = <<-DESC
                               This is the Radar integration for mParticle.

--- a/mParticle-Radar.podspec
+++ b/mParticle-Radar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                    = 'mParticle-Radar'
-  s.version                 = '6.15.18'
+  s.version                 = '6.15.19'
   s.summary                 = 'Radar integration for mParticle'
   s.description             = <<-DESC
                               This is the Radar integration for mParticle.

--- a/mParticle-Radar.podspec
+++ b/mParticle-Radar.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.ios.source_files        = 'mParticle-Radar/*.{h,m,mm}'
   s.ios.frameworks          = 'CoreLocation'
   s.ios.dependency          'mParticle-Apple-SDK/mParticle', '~> 6.15.0'
-  s.ios.dependency          'RadarSDK', '~> 1.2.0'
+  s.ios.dependency          'RadarSDK', '~> 1.3.0'
   s.ios.pod_target_xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/RadarSDK/**',
                                 'OTHER_LDFLAGS' => '$(inherited) -framework "RadarSDK"' }
 end

--- a/mParticle-Radar/MPKitRadar.m
+++ b/mParticle-Radar/MPKitRadar.m
@@ -83,7 +83,7 @@ NSUInteger MPKitInstanceCompanyName = 117;
         NSString *identityString = userIdentity[kMPUserIdentityIdKey];
 
         if (identityType == MPUserIdentityCustomerId) {
-            Radar.setUserId(userId);
+            [Radar setUserId:identityString];
             break;
         }
     }

--- a/mParticle-Radar/MPKitRadar.m
+++ b/mParticle-Radar/MPKitRadar.m
@@ -142,24 +142,7 @@ NSUInteger MPKitInstanceCompanyName = 117;
 #pragma mark User attributes and identities
 
 - (MPKitExecStatus *)setUserIdentity:(NSString *)identityString identityType:(MPUserIdentity)identityType {
-    if (identityType == MPUserIdentityAlias) {
-        [Radar reidentifyUserFromOldUserId:identityString];
-
-        for (NSDictionary<NSString *, id> *userIdentity in self.userIdentities) {
-            MPUserIdentity identityType = (MPUserIdentity)[userIdentity[kMPUserIdentityTypeKey] integerValue];
-            NSString *identityString = userIdentity[kMPUserIdentityIdKey];
-
-            if (identityType == MPUserIdentityCustomerId) {
-                Radar.setUserId(userId);
-                break;
-            }
-        }
-
-        if (runAutomatically) {
-            [self tryTrackOnce];
-            [self tryStartTracking];
-        }
-    } else if (identityType == MPUserIdentityCustomerId) {
+    if (identityType == MPUserIdentityCustomerId) {
         [Radar setUserId:identityString];
 
         if (runAutomatically) {

--- a/mParticle-Radar/MPKitRadar.m
+++ b/mParticle-Radar/MPKitRadar.m
@@ -78,6 +78,8 @@ NSUInteger MPKitInstanceCompanyName = 117;
 
     [Radar initializeWithPublishableKey:publishableKey];
 
+    // TODO proactively get customer ID and call [Radar setUserId:customerId];?
+
     _configuration = configuration;
 
     if (startImmediately) {
@@ -132,7 +134,15 @@ NSUInteger MPKitInstanceCompanyName = 117;
 #pragma mark User attributes and identities
 
 - (MPKitExecStatus *)setUserIdentity:(NSString *)identityString identityType:(MPUserIdentity)identityType {
-    if (identityType == MPUserIdentityCustomerId) {
+    if (identityType == MPUserIdentityAlias) {
+        [Radar reidentifyUserFromOldUserId:identityString];
+        // TODO get new customer ID and call [Radar setUserId:customerId];?
+
+        if (runAutomatically) {
+            [self tryTrackOnce];
+            [self tryStartTracking];
+        }
+    } else if (identityType == MPUserIdentityCustomerId) {
         [Radar setUserId:identityString];
 
         if (runAutomatically) {

--- a/mParticle-Radar/MPKitRadar.m
+++ b/mParticle-Radar/MPKitRadar.m
@@ -23,8 +23,10 @@
 #import "RadarSDK.h"
 #endif
 
-NSString *const KEY_PUBLISHABLE_KEY = @"publishableKey";
-NSString *const KEY_RUN_AUTOMATICALLY = @"runAutomatically";
+static NSString * const KEY_PUBLISHABLE_KEY = @"publishableKey";
+static NSString * const KEY_RUN_AUTOMATICALLY = @"runAutomatically";
+static NSString * const kMPUserIdentityTypeKey = @"n";
+static NSString * const kMPUserIdentityIdKey = @"i";
 
 NSUInteger MPKitInstanceCompanyName = 117;
 

--- a/mParticle-Radar/MPKitRadar.m
+++ b/mParticle-Radar/MPKitRadar.m
@@ -78,7 +78,15 @@ NSUInteger MPKitInstanceCompanyName = 117;
 
     [Radar initializeWithPublishableKey:publishableKey];
 
-    // TODO proactively get customer ID and call [Radar setUserId:customerId];?
+    for (NSDictionary<NSString *, id> *userIdentity in self.userIdentities) {
+        MPUserIdentity identityType = (MPUserIdentity)[userIdentity[kMPUserIdentityTypeKey] integerValue];
+        NSString *identityString = userIdentity[kMPUserIdentityIdKey];
+
+        if (identityType == MPUserIdentityCustomerId) {
+            Radar.setUserId(userId);
+            break;
+        }
+    }
 
     _configuration = configuration;
 
@@ -136,7 +144,16 @@ NSUInteger MPKitInstanceCompanyName = 117;
 - (MPKitExecStatus *)setUserIdentity:(NSString *)identityString identityType:(MPUserIdentity)identityType {
     if (identityType == MPUserIdentityAlias) {
         [Radar reidentifyUserFromOldUserId:identityString];
-        // TODO get new customer ID and call [Radar setUserId:customerId];?
+
+        for (NSDictionary<NSString *, id> *userIdentity in self.userIdentities) {
+            MPUserIdentity identityType = (MPUserIdentity)[userIdentity[kMPUserIdentityTypeKey] integerValue];
+            NSString *identityString = userIdentity[kMPUserIdentityIdKey];
+
+            if (identityType == MPUserIdentityCustomerId) {
+                Radar.setUserId(userId);
+                break;
+            }
+        }
 
         if (runAutomatically) {
             [self tryTrackOnce];


### PR DESCRIPTION
TODO: Can we proactively get customer ID and call `[Radar setUserId:customerId]` on initialization and on alias changes?