### PR TITLE
Small tracking fixes

### DIFF
--- a/mParticle-Radar/MPKitRadar.m
+++ b/mParticle-Radar/MPKitRadar.m
@@ -94,8 +94,9 @@ NSUInteger MPKitInstanceCompanyName = 117;
         _started = YES;
 
         if (runAutomatically) {
-            [self tryTrackOnce];
             [self tryStartTracking];
+        } else {
+            [Radar stopTracking];
         }
 
         dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
- Disable tracking when `runAutomatically` is false. 
- Only track once on app foreground (before we were also calling `trackOnce` on kit create) 