### PR TITLE
Identified an exception when mpId comes through as nil

### DIFF
--- a/mParticle-Radar/MPKitRadar.m
+++ b/mParticle-Radar/MPKitRadar.m
@@ -144,8 +144,10 @@ NSUInteger MPKitInstanceCompanyName = 117;
 
 - (void)setUserAndTrack:(FilteredMParticleUser *)user  {
     NSString *mpId = [self getMpId:user];
-    [self setRadarMetadata:mpId];
-    [self setRadarUserId:user];
+    if (mpId != nil) {
+        [self setRadarMetadata:mpId];
+        [self setRadarUserId:user];
+    }    
     if (runAutomatically) {
         [self tryTrackOnce];
         [self tryStartTracking];


### PR DESCRIPTION
Identified an issue where mpId is coming through as nil and resulting in Sentry errors. Adding another nil check check prior to calling setRadarMetadata where the exception is occurring on thread [MPKitRadar setRadarMetadata:] with “-[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[0]“