### PR TITLE
fix: Change version resolver rule

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
                .upToNextMajor(from: "8.0.0")),
       .package(name: "RadarSDK",
                url: "https://github.com/radarlabs/radar-sdk-ios",
-               .upToNextMinor(from: "3.4.0")),
+               .upToNextMajor(from: "3.4.0")),
     ],
     targets: [
         .target(


### PR DESCRIPTION
 ## Summary
 - change the version rule for radar dep thus it would resolve to the latest version
