### PR TITLE
Bump radar to 3.8.9

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "radarlabs/radar-sdk-ios" ~> 3.4
+github "radarlabs/radar-sdk-ios" ~> 3.8
 github "mparticle/mparticle-apple-sdk" ~> 8.0

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
                .upToNextMajor(from: "8.0.0")),
       .package(name: "RadarSDK",
                url: "https://github.com/radarlabs/radar-sdk-ios",
-               .upToNextMinor(from: "3.4.0")),
+               .upToNextMinor(from: "3.8.0")),
     ],
     targets: [
         .target(

--- a/mParticle-Radar.podspec
+++ b/mParticle-Radar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                    = 'mParticle-Radar'
-  s.version                 = '8.0.5'
+  s.version                 = '8.0.6'
   s.summary                 = 'Radar integration for mParticle'
   s.description             = <<-DESC
                               This is the Radar integration for mParticle.
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.ios.source_files        = 'mParticle-Radar/*.{h,m,mm}'
   s.ios.frameworks          = 'CoreLocation'
   s.ios.dependency          'mParticle-Apple-SDK/mParticle', '~> 8.0'
-  s.ios.dependency          'RadarSDK', '~> 3.4.4'
+  s.ios.dependency          'RadarSDK', '~> 3.8.9'
   s.ios.pod_target_xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/RadarSDK/**',
                                 'OTHER_LDFLAGS' => '$(inherited) -framework "RadarSDK"',
 				'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
- upgrades `RadarSDK` dependency to latest, `3.8.9`.

 ## Testing Plan
 I haven't tested this locally – it's my first time contributing to this repo. Is there a preferred demo / example app to test with? Should be trivial.


 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
