### PR TITLE
fix: Header imports for mParticle SDK

### DIFF
--- a/mParticle-Radar.podspec
+++ b/mParticle-Radar.podspec
@@ -17,7 +17,5 @@ Pod::Spec.new do |s|
   s.ios.dependency          'mParticle-Apple-SDK/mParticle', '~> 8.0'
   s.ios.dependency          'RadarSDK', '~> 3.4.4'
   s.ios.pod_target_xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/RadarSDK/**',
-                                'OTHER_LDFLAGS' => '$(inherited) -framework "RadarSDK"',
-				'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-  s.ios.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
+                                'OTHER_LDFLAGS' => '$(inherited) -framework "RadarSDK"' }
 end

--- a/mParticle-Radar/MPKitRadar.h
+++ b/mParticle-Radar/MPKitRadar.h
@@ -1,8 +1,13 @@
 #import <Foundation/Foundation.h>
 #if defined(__has_include) && __has_include(<mParticle_Apple_SDK/mParticle.h>)
-#import <mParticle_Apple_SDK/mParticle.h>
+    #import <mParticle_Apple_SDK/mParticle.h>
+    #import <mParticle_Apple_SDK/mParticle_Apple_SDK-Swift.h>
+#elif defined(__has_include) && __has_include(<mParticle_Apple_SDK_NoLocation/mParticle.h>)
+    #import <mParticle_Apple_SDK_NoLocation/mParticle.h>
+    #import <mParticle_Apple_SDK_NoLocation/mParticle_Apple_SDK-Swift.h>
 #else
-#import "mParticle.h"
+    #import "mParticle.h"
+    #import "mParticle_Apple_SDK-Swift.h"
 #endif
 
 @interface MPKitRadar : NSObject <MPKitProtocol>


### PR DESCRIPTION
## Summary
Adds headers for accessing public Swift classes in the core SDK. Marked as fix so semantic release will make a patch version bump instead of minor version bump.

## Testing Instructions
Tested by compiling and running a local app to see that there were no header or Swift related errors.